### PR TITLE
Refactoring: Fix unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.17</version>
+				<version>2.19</version>
 				<configuration>
+					<skipAfterFailureCount>1</skipAfterFailureCount>
 					<excludes>
 						<!-- skip some tests for servers without IPv6 support.  -->
 						<exclude>**/BinaryIPV6ClientTest.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.19</version>
 				<configuration>
-					<skipAfterFailureCount>1</skipAfterFailureCount>
+					<!--skipAfterFailureCount>1</skipAfterFailureCount-->
 					<excludes>
 						<!-- skip some tests for servers without IPv6 support.  -->
 						<exclude>**/BinaryIPV6ClientTest.java</exclude>

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -79,6 +79,10 @@ public abstract class ClientBaseCase extends TestCase {
 		@Override
 		public ConnectionFactory build() {
 			return new ConnectionFactory() {
+				/*
+				 * CAUTION! Never override this createConnection() method, or your code could not
+				 * work as you expected. See https://github.com/jam2in/arcus-java-client/issue/4
+				 */
 				@Override
 				public MemcachedConnection createConnection(
 						List<InetSocketAddress> addrs) throws IOException {

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -70,6 +70,7 @@ public abstract class ClientBaseCase extends TestCase {
 	private static class CFB extends ConnectionFactoryBuilder {
 
 		private final ConnectionFactory inner;
+		private Collection<ConnectionObserver> observers = Collections.emptyList();
 
 		public CFB(ConnectionFactory cf) {
 			this.inner = cf;
@@ -81,7 +82,8 @@ public abstract class ClientBaseCase extends TestCase {
 				@Override
 				public MemcachedConnection createConnection(
 						List<InetSocketAddress> addrs) throws IOException {
-					return inner.createConnection(addrs);
+					return new MemcachedConnection(getReadBufSize(), this, addrs,
+									getInitialObservers(), getFailureMode(), getOperationFactory());
 				}
 
 				@Override
@@ -137,7 +139,7 @@ public abstract class ClientBaseCase extends TestCase {
 
 				@Override
 				public Collection<ConnectionObserver> getInitialObservers() {
-					return inner.getInitialObservers();
+					return observers;
 				}
 
 				@Override
@@ -253,6 +255,7 @@ public abstract class ClientBaseCase extends TestCase {
 		@Override
 		public ConnectionFactoryBuilder setInitialObservers(
 				Collection<ConnectionObserver> obs) {
+			this.observers = obs;
 			return this;
 		}
 	}
@@ -284,27 +287,7 @@ public abstract class ClientBaseCase extends TestCase {
 	}
 
 	protected void openDirect(CFB cfb) throws Exception {
-		final CountDownLatch latch = new CountDownLatch(
-				ARCUS_HOST.split(",").length);
-
-		final ConnectionObserver obs = new ConnectionObserver() {
-			@Override
-			public void connectionEstablished(SocketAddress sa,
-					int reconnectCount) {
-				latch.countDown();
-			}
-
-			@Override
-			public void connectionLost(SocketAddress sa) {
-				assert false : "Connection is failed.";
-			}
-
-		};
-		cfb.setInitialObservers(Collections.singleton(obs));
-
 		client = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
-//		latch.await();
-		Thread.sleep(1000L);
 	}
 
 	protected Collection<String> stringify(Collection<?> c) {

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -282,7 +282,7 @@ public abstract class ClientBaseCase extends TestCase {
 		if (USE_ZK) {
 			openFromZK(new CFB(cf));
 		} else {
-			openDirect(new CFB(cf));
+			openDirect(cf);
 		}
 	}
 
@@ -290,8 +290,8 @@ public abstract class ClientBaseCase extends TestCase {
 		client = ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID, cfb);
 	}
 
-	protected void openDirect(CFB cfb) throws Exception {
-		client = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
+	protected void openDirect(ConnectionFactory cf) throws Exception {
+		client = new ArcusClient(cf, AddrUtil.getAddresses(ARCUS_HOST));
 	}
 
 	protected Collection<String> stringify(Collection<?> c) {

--- a/src/test/java/net/spy/memcached/LongClientTest.java
+++ b/src/test/java/net/spy/memcached/LongClientTest.java
@@ -23,12 +23,6 @@ public class LongClientTest extends ClientBaseCase {
 		client.shutdown();
 		initClient(new DefaultConnectionFactory(){
 			@Override
-			public MemcachedConnection createConnection(
-					List<InetSocketAddress> addrs) throws IOException {
-				MemcachedConnection rv = super.createConnection(addrs);
-				return rv;
-			}
-			@Override
 			public long getOperationTimeout() {
 				return 15000;
 			}

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -7,18 +7,73 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.compat.SpyObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Test observer hooks.
  */
+@RunWith(JUnit4ClassRunner.class)
 public class ObserverTest extends ClientBaseCase {
 
+	@Before
+	public void setup() throws Exception {
+		super.setUp();
+	}
+
+	@Test
 	public void testConnectionObserver() throws Exception {
 		ConnectionObserver obs = new LoggingObserver();
 		assertTrue("Didn't add observer.", client.addObserver(obs));
 		assertTrue("Didn't remove observer.", client.removeObserver(obs));
 		assertFalse("Removed observer more than once.",
 			client.removeObserver(obs));
+	}
+
+	@Test
+	public void testInitialObservers() throws Exception {
+		assumeTrue(!USE_ZK);
+		assertTrue("Couldn't shut down within five seconds",
+						client.shutdown(5, TimeUnit.SECONDS));
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		final ConnectionObserver obs = new ConnectionObserver() {
+
+			public void connectionEstablished(SocketAddress sa,
+																				int reconnectCount) {
+				latch.countDown();
+			}
+
+			public void connectionLost(SocketAddress sa) {
+				assert false : "Should not see this.";
+			}
+
+		};
+
+		// Get a new client
+		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder() {
+			@Override
+			public ConnectionFactory build() {
+				return new DefaultConnectionFactory() {
+					@Override
+					public Collection<ConnectionObserver> getInitialObservers() {
+						return Collections.singleton(obs);
+					}
+				};
+			}
+		};
+
+		client = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
+
+		assertTrue("Didn't detect connection",
+						latch.await(2, TimeUnit.SECONDS));
+		assertTrue("Did not install observer.", client.removeObserver(obs));
+		assertFalse("Didn't clean up observer.", client.removeObserver(obs));
 	}
 
 	static class LoggingObserver extends SpyObject
@@ -33,5 +88,10 @@ public class ObserverTest extends ClientBaseCase {
 			getLogger().info("Connection lost from %s", sa);
 		}
 
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		super.tearDown();
 	}
 }

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -21,40 +21,6 @@ public class ObserverTest extends ClientBaseCase {
 			client.removeObserver(obs));
 	}
 
-	public void testInitialObservers() throws Exception {
-		assertTrue("Couldn't shut down within five seconds",
-			client.shutdown(5, TimeUnit.SECONDS));
-
-		final CountDownLatch latch = new CountDownLatch(1);
-		final ConnectionObserver obs = new ConnectionObserver() {
-
-			public void connectionEstablished(SocketAddress sa,
-					int reconnectCount) {
-				latch.countDown();
-			}
-
-			public void connectionLost(SocketAddress sa) {
-				assert false : "Should not see this.";
-			}
-
-		};
-
-		// Get a new client
-		initClient(new DefaultConnectionFactory() {
-
-			@Override
-			public Collection<ConnectionObserver> getInitialObservers() {
-				return Collections.singleton(obs);
-			}
-
-		});
-
-		assertTrue("Didn't detect connection",
-				latch.await(2, TimeUnit.SECONDS));
-		assertTrue("Did not install observer.", client.removeObserver(obs));
-		assertFalse("Didn't clean up observer.", client.removeObserver(obs));
-	}
-
 	static class LoggingObserver extends SpyObject
 		implements ConnectionObserver {
 		public void connectionEstablished(SocketAddress sa,

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -56,19 +56,12 @@ public class ObserverTest extends ClientBaseCase {
 		};
 
 		// Get a new client
-		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder() {
+		initClient(new DefaultConnectionFactory() {
 			@Override
-			public ConnectionFactory build() {
-				return new DefaultConnectionFactory() {
-					@Override
-					public Collection<ConnectionObserver> getInitialObservers() {
-						return Collections.singleton(obs);
-					}
-				};
+			public Collection<ConnectionObserver> getInitialObservers() {
+				return Collections.singleton(obs);
 			}
-		};
-
-		client = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
+		});
 
 		assertTrue("Didn't detect connection",
 						latch.await(2, TimeUnit.SECONDS));

--- a/src/test/java/net/spy/memcached/QueueOverflowTest.java
+++ b/src/test/java/net/spy/memcached/QueueOverflowTest.java
@@ -29,12 +29,6 @@ public class QueueOverflowTest extends ClientBaseCase {
 		// functional after such conditions occur.
 		initClient(new DefaultConnectionFactory(5, 1024) {
 			@Override
-			public MemcachedConnection createConnection(
-					List<InetSocketAddress> addrs) throws IOException {
-				MemcachedConnection rv = super.createConnection(addrs);
-				return rv;
-			}
-			@Override
 			public long getOperationTimeout() {
 				return 1000;
 			}

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -18,20 +18,32 @@ package net.spy.memcached;
 
 import junit.framework.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runner.RunWith;
 
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(JUnit4ClassRunner.class)
 public class ArcusClientConnectTest extends BaseIntegrationTest {
 
+	@Before
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		// This test assumes we use ZK
+		assumeTrue(USE_ZK);
 		openFromZK();
 	}
 
+	@After
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		// do nothing
 	}
 
+	@Test
 	public void testOpenAndWait() {
 		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
 		ArcusClient client = ArcusClient.createArcusClient(ZK_HOST,

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -18,20 +18,32 @@ package net.spy.memcached;
 
 import junit.framework.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runner.RunWith;
 
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(JUnit4ClassRunner.class)
 public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
 
+	@Before
 	@Override
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 		// This test assumes we use ZK
+		assumeTrue(USE_ZK);
 		openFromZK();
 	}
 
+	@After
 	@Override
-	protected void tearDown() throws Exception {
+	public void tearDown() throws Exception {
 		super.tearDown();
 	}
 
+	@Test
 	public void testCreateSingleClient() {
 		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
 		cfb.setFrontCacheExpireTime(10);
@@ -40,6 +52,7 @@ public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
 		ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID, cfb);
 	}
 
+	@Test
 	public void testCreatePool() {
 		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
 		cfb.setFrontCacheExpireTime(10);
@@ -48,6 +61,7 @@ public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
 		ArcusClient.createArcusClientPool(ZK_HOST, ZK_SERVICE_ID, cfb, 4);
 	}
 
+	@Test
 	public void testKV() {
 		ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
 		cfb.setFrontCacheExpireTime(10);


### PR DESCRIPTION
#3 #4 관련 수정 PR 입니다. (20일 수요일 오전에 논의 제안했던 내용입니다. 해결책이 보여 우선 PR 작성합니다. 논의하기로 했던 시간에 코드 내용 및 배경 설명하고 간략히 함께 리뷰하는 시간으로 활용하면 될 것 같습니다.)

- USE_ZK 옵션은 true / false 두 경우 모두 수행하는 것으로 살려 두었습니다.
- CFB와 `inner` object 가 올바른 ConnectionObserver 를 참조할 수 있도록 수정하였습니다. CFB 자체를 완전히 걷어내는 수정은, spymemcached 와 완전 결별-_-을 선언하지 않는다면 불가능합니다.
- Maven test 수행시 test failure 또는 error 가 발생하면 즉시 남은 test 를 skip 하도록 mvn 설정을 수정하였습니다.
- 특정 테스트는 USE_ZK == true 일 때만 수행하도록 수정하였습니다. 이 과정에서 해당 테스트 클래스들을 JUnit 4 style 로 수정하였습니다. (기존의 구현은 JUnit 3 style)

Review
- [x] @jhpark816 
- [x] @whchoi83 