### PR TITLE
move matchStatus line in else condition

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -60,9 +60,6 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
 	@Override
 	public void handleLine(String line) {
-		OperationStatus status = matchStatus(line, END, NOT_FOUND,
-				ATTR_ERROR_NOT_FOUND);
-
 		if (line.startsWith("ATTR ")) {
 			getLogger().debug("Got line %s", line);
 
@@ -72,12 +69,12 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 			assert stuff[0].equals("ATTR");
 
 			cb.gotAttribute(key, stuff[1]);
-		} else if (status.isSuccess()) {
-			getLogger().debug(status);
-			getCallback().receivedStatus(status);
-			transitionState(OperationState.COMPLETE);
 		} else {
-			getLogger().debug(status);
+			OperationStatus status = matchStatus(line, END, NOT_FOUND,
+					ATTR_ERROR_NOT_FOUND);
+			if (getLogger().isDebugEnabled()) {
+				getLogger().debug(status);
+			}
 			getCallback().receivedStatus(status);
 			transitionState(OperationState.COMPLETE);
 		}


### PR DESCRIPTION
아래 이슈 수정사항 입니다.
https://github.com/jam2in/arcus-java-client/issues/14

matchStatus 의 호출 위치가 잘못되어 불필요한 로그가 출력되는 것을 수정하기 위해 호출 위치를 변경하고,
중복된 if 조건의 내용을 하나로 합쳤습니다.

리뷰 부탁드립니다.

- [x] @aiceru 
- [x] @jhpark816 