### PR TITLE
delete unnecessary log

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -70,9 +70,6 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
 		}
 		if(rv == null) {
 			rv=new OperationStatus(false, line);
-			/* ENABLE_REPLICATION if */
-			getLogger().error("Unexpected operation status : %s", line);
-			/* ENABLE_REPLICATION end */
 		}
 		return rv;
 	}


### PR DESCRIPTION
https://github.com/jam2in/arcus-java-client/issues/21 이슈입니다.

replication 개발 당시 디버그 목적으로 넣었던 log 를 제거하지 않고 release 했습니다.
불필요한 로그라서 삭제합니다.