### PR TITLE
Feature : Add unit tests for SMGet with ElementMultiFlagsFilter

### DIFF
--- a/docs/06-btree-API.md
+++ b/docs/06-btree-API.md
@@ -199,7 +199,7 @@ Integer count = future.get();
 3. 일치 여부 판단을 위한 값 0x0104 등록
 
 ElementMultiFlagsFilter로 최대 100개 compare value를 지정할 수 있으며,
-asyncBopGet, asyncBopCount, asyncBopDelete 에서만 사용이 가능하다.
+asyncBopGet, asyncBopCount, asyncBopDelete, asyncBopSortMergeGet 에서만 사용이 가능하다.
 
 ### Element Flag Update 객체
 

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached.btreesmget;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,9 +24,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import junit.framework.Assert;
+import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
-import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.collection.ElementMultiFlagsFilter;
 import net.spy.memcached.collection.SMGetElement;
 import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
@@ -616,6 +618,125 @@ public class SMGetTest extends BaseIntegrationTest {
 
 			Map<String, CollectionOperationStatus> missed = future.getMissedKeys();
 			Assert.assertEquals(testSize / 2, missed.size());
+		} catch (Exception e) {
+			future.cancel(true);
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	public void testSMGetWithElementMultiFlagsFilter() {
+		int testSize = 2000;
+
+		try {
+			keyList = new ArrayList<String>();
+			for (int i = 0; i < testSize; i++) {
+				mc.delete(KEY + i).get();
+				keyList.add(KEY + i);
+			}
+			for (int i = 0; i < testSize; i++) {
+				mc.asyncBopInsert(KEY + i, i, ByteBuffer.allocate(4).putInt(i).array(), "VALUE" + i,
+								new CollectionAttributes()).get();
+			}
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
+
+		SMGetMode smgetMode = SMGetMode.UNIQUE;
+		ElementMultiFlagsFilter multiFlagsFilter = new ElementMultiFlagsFilter();
+		multiFlagsFilter.setCompOperand(ElementFlagFilter.CompOperands.Equal);
+		for (int i = 0; i < 99; i++) {
+			multiFlagsFilter.addCompValue(ByteBuffer.allocate(4).putInt(i).array());
+		}
+		multiFlagsFilter.addCompValue(new byte[] {(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF});
+
+		/* old SMGet */
+		SMGetFuture<List<SMGetElement<Object>>> oldFuture = mc
+						.asyncBopSortMergeGet(keyList, 0, testSize, multiFlagsFilter, 0, 1000);
+
+		try {
+			List<SMGetElement<Object>> map = oldFuture.get(1000L, TimeUnit.SECONDS);
+			Assert.assertEquals(99, map.size());
+
+			List<String> missed = oldFuture.getMissedKeyList();
+			Assert.assertEquals(0, missed.size());
+		} catch (Exception e) {
+			oldFuture.cancel(true);
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+
+		SMGetFuture<List<SMGetElement<Object>>> future = mc
+						.asyncBopSortMergeGet(keyList, 0, testSize, multiFlagsFilter, 1000, smgetMode);
+
+		try {
+			List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
+			Assert.assertEquals(99, map.size());
+
+			Map<String, CollectionOperationStatus> missed = future.getMissedKeys();
+			Assert.assertEquals(0, missed.size());
+		} catch (Exception e) {
+			future.cancel(true);
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	public void testByteArrayBkeySMGetWithElementMultiFlagsFilter() {
+		int testSize = 2000;
+
+		try {
+			keyList = new ArrayList<String>();
+			for (int i = 0; i < testSize; i++) {
+				mc.delete(KEY + i).get();
+				keyList.add(KEY + i);
+			}
+			for (int i = 0; i < testSize; i++) {
+				mc.asyncBopInsert(KEY + i, ByteBuffer.allocate(4).putInt(i).array(),
+								ByteBuffer.allocate(4).putInt(i).array(), "VALUE" + i,
+								new CollectionAttributes()).get();
+			}
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
+
+		SMGetMode smgetMode = SMGetMode.UNIQUE;
+		ElementMultiFlagsFilter multiFlagsFilter = new ElementMultiFlagsFilter();
+		multiFlagsFilter.setCompOperand(ElementFlagFilter.CompOperands.Equal);
+		for (int i = 0; i < 99; i++) {
+			multiFlagsFilter.addCompValue(ByteBuffer.allocate(4).putInt(i).array());
+		}
+		multiFlagsFilter.addCompValue(new byte[] {(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF});
+
+		/* old SMGet */
+		SMGetFuture<List<SMGetElement<Object>>> oldFuture = mc
+						.asyncBopSortMergeGet(keyList, new byte[]{0,0,0,0},
+										ByteBuffer.allocate(4).putInt(testSize).array(),
+										multiFlagsFilter, 0, 1000);
+
+		try {
+			List<SMGetElement<Object>> map = oldFuture.get(1000L, TimeUnit.SECONDS);
+			Assert.assertEquals(99, map.size());
+
+			List<String> missed = oldFuture.getMissedKeyList();
+			Assert.assertEquals(0, missed.size());
+		} catch (Exception e) {
+			oldFuture.cancel(true);
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+
+		SMGetFuture<List<SMGetElement<Object>>> future = mc
+						.asyncBopSortMergeGet(keyList, new byte[]{0,0,0,0},
+										ByteBuffer.allocate(4).putInt(testSize).array(),
+										multiFlagsFilter, 1000, smgetMode);
+
+		try {
+			List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
+			Assert.assertEquals(99, map.size());
+
+			Map<String, CollectionOperationStatus> missed = future.getMissedKeys();
+			Assert.assertEquals(0, missed.size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();


### PR DESCRIPTION
- Review
  - [x] @jhpark816 
  - [ ] @whchoi83 

`asyncBopSortMergeGet` 에서 `ElementMultiFlagsFilter` 를 사용하는 경우에 대한 unit test 를 추가하였습니다. 더불어, 문서에서 ElementMultiFlagsFilter 를 사용할 수 있는 케이스에 asyncBopSortMergeGet 을 추가하였습니다.