### PR TITLE
Refactoring seperate CacheMonitor Zookeeper watcher from CacheManager

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -264,7 +264,6 @@ public class CacheManager extends SpyThread implements Watcher,
 				getLogger().warn("Session expired. Trying to reconnect to the Arcus admin." + getInfo());
 				if (cacheMonitor != null)
 					cacheMonitor.shutdown();
-				closing();
 				break;
 			}
 		}

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -248,16 +248,25 @@ public class CacheManager extends SpyThread implements Watcher,
 			switch (event.getState()) {
 			case SyncConnected:
 				getLogger().info("Connected to Arcus admin. (%s@%s)", serviceCode, hostPort);
-				zkInitLatch.countDown();
+				if (cacheMonitor != null) {
+					getLogger().warn("Reconnected to the Arcus admin. " + getInfo());
+				} else {
+					zkInitLatch.countDown();
+					getLogger().debug("cm is null, servicecode : %s, state:%s, type:%s",
+									serviceCode, event.getState(), event.getType());
+				}
+				break;
+			case Disconnected:
+				getLogger().warn("Disconnected from the Arcus admin. Trying to reconnect. " + getInfo());
+				break;
+			case Expired:
+				// If the session was expired, just shutdown this client to be re-initiated.
+				getLogger().warn("Session expired. Trying to reconnect to the Arcus admin." + getInfo());
+				if (cacheMonitor != null)
+					cacheMonitor.shutdown();
+				closing();
+				break;
 			}
-		}
-		
-		if (cacheMonitor != null) {
-			cacheMonitor.process(event);
-		} else {
-			getLogger().debug(
-					"cm is null, servicecode : %s, state:%s, type:%s",
-					serviceCode, event.getState(), event.getType());
 		}
 	}
 
@@ -366,6 +375,14 @@ public class CacheManager extends SpyThread implements Watcher,
 	
 	public List<String> getPrevChildren() {
 		return this.prevChildren;
+	}
+	
+	private String getInfo() {
+		String zkSessionId = null;
+		if (zk != null) {
+			zkSessionId = "0x" + Long.toHexString(zk.getSessionId());
+		}
+		return "[serviceCode=" + serviceCode + ", adminSessionId=" + zkSessionId + "]";
 	}
 
 	/**

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -139,6 +139,7 @@ public class CacheMonitor extends SpyObject implements Watcher,
 	public void shutdown() {
 		getLogger().info("Shutting down the CacheMonitor. " + getInfo());
 		dead = true;
+		listener.closing();
 	}
 	
 	private String getInfo() {

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -87,27 +87,8 @@ public class CacheMonitor extends SpyObject implements Watcher,
 	 * Processes every events from the ZooKeeper.
 	 */
 	public void process(WatchedEvent event) {
-		if (event.getType() == Event.EventType.None) {
-			// Processes session events
-			switch (event.getState()) {
-			case SyncConnected:
-				getLogger().warn("Reconnected to the Arcus admin. " + getInfo());
-				return;
-			case Disconnected:
-				getLogger().warn("Disconnected from the Arcus admin. Trying to reconnect. " + getInfo());
-				return;
-			case Expired:
-				// If the session was expired, just shutdown this client to be re-initiated.
-				getLogger().warn("Session expired. Trying to reconnect to the Arcus admin." + getInfo());
-				shutdown();
-				return;
-			}
-		} else {
-			// Set a new watch on the znode when there are any changes in it.
-			if (event.getType() == Event.EventType.NodeChildrenChanged) {
-				asyncGetCacheList();
-			}
-		}
+		if (event.getType() == Event.EventType.NodeChildrenChanged)
+			asyncGetCacheList();
 	}
 
 	/**
@@ -149,7 +130,7 @@ public class CacheMonitor extends SpyObject implements Watcher,
 			getLogger().debug("Set a new watch on " + (cacheListZPath + serviceCode));
 		}
 		
-		zk.getChildren(cacheListZPath + serviceCode, true, this, null);
+		zk.getChildren(cacheListZPath + serviceCode, this, this, null);
 	}
 
 	/**
@@ -158,7 +139,6 @@ public class CacheMonitor extends SpyObject implements Watcher,
 	public void shutdown() {
 		getLogger().info("Shutting down the CacheMonitor. " + getInfo());
 		dead = true;
-		listener.closing();
 	}
 	
 	private String getInfo() {


### PR DESCRIPTION
CacheManager 를 default watcher 로 등록하고 모든 event 를 받아 CacheMonitor 로 전달하던 것에서 CacheManager 와 CacheMonitor 의 역할에 맞게 서로 분리했습니다.

차후에 MigrationMonitor(미정) 를 추가하기 위해서라 default watcher 를 사용하던 것에서 목적에 맞게 watcher 를 분리하는 작업이 필요합니다

본 PR은 리뷰가 끝난 뒤에 Mingration 개발이 끝나고 PR  & Merge 시점에 함께 merge 하는 것이 좋을 것 같습니다.
추가적인 테스트와 migration 개발 중 변경 가능성이 있어서 입니다.

- [x] @MinWooJin 
- [x] @minkikim89 
- [x] @jhpark816 